### PR TITLE
Add CrossProjectModuleId

### DIFF
--- a/examples/dependency-configurations/build.sbt
+++ b/examples/dependency-configurations/build.sbt
@@ -1,0 +1,12 @@
+lazy val mainCross = Project("main", file("main")).cross
+  .dependsOn(testCross % "test")
+
+lazy val mainCross_2_10 = mainCross("2.10.5")
+
+lazy val mainCross_2_11 = mainCross("2.11.6")
+
+lazy val testCross = Project("common", file("common")).cross
+
+lazy val testCross_2_10 = testCross("2.10.5")
+
+lazy val testCross_2_11 = testCross("2.11.6")

--- a/examples/dependency-configurations/project/build.sbt
+++ b/examples/dependency-configurations/project/build.sbt
@@ -1,0 +1,4 @@
+addSbtPlugin("com.lucidchart" % "sbt-cross" % "2.0-SNAPSHOT")
+
+resolvers += Resolver.sonatypeRepo("releases")
+

--- a/sbt-cross/src/main/scala/com/lucidchart/sbtcross/CrossProject.scala
+++ b/sbt-cross/src/main/scala/com/lucidchart/sbtcross/CrossProject.scala
@@ -4,7 +4,7 @@ import sbt._
 import sbt.Keys._
 import sbt.cross.CrossVersionUtil
 
-class CrossProject(project: Project, dependencies: Seq[CrossProject] = Seq()) {
+class CrossProject(project: Project, dependencies: Seq[CrossProjectModuleId] = Seq()) {
 
   def aggregate(parts: AggregateArgument*): Project = {
     val projects = parts.map {
@@ -26,7 +26,7 @@ class CrossProject(project: Project, dependencies: Seq[CrossProject] = Seq()) {
         }
       )
       .dependsOn(
-        dependencies.map(_.ref(version): ClasspathDep[ProjectReference]): _*
+        dependencies.map(_(version)): _*
       )
   }
 
@@ -40,7 +40,7 @@ class CrossProject(project: Project, dependencies: Seq[CrossProject] = Seq()) {
     base / binaryVersion
   }
 
-  def dependsOn(crossProjects: CrossProject*): CrossProject =
+  def dependsOn(crossProjects: CrossProjectModuleId*): CrossProject =
     new CrossProject(project, dependencies ++ crossProjects)
 
   private def idForVersion(version: String) = {
@@ -48,7 +48,11 @@ class CrossProject(project: Project, dependencies: Seq[CrossProject] = Seq()) {
     s"${project.id}-${binaryVersion.replace(".", "_")}"
   }
 
-  private def ref(version: String): ProjectReference =
+  implicit def moduleId: CrossProjectModuleId = CrossProjectModuleId(this)
+
+  def ref(version: String): ProjectReference =
     Project(idForVersion(version), baseForVersion(version))
+
+  def %(configurations: String) = CrossProjectModuleId(this, Some(configurations))
 
 }

--- a/sbt-cross/src/main/scala/com/lucidchart/sbtcross/CrossProjectModuleId.scala
+++ b/sbt-cross/src/main/scala/com/lucidchart/sbtcross/CrossProjectModuleId.scala
@@ -1,0 +1,12 @@
+package com.lucidchart.sbtcross
+
+import sbt._
+
+case class CrossProjectModuleId(crossProject: CrossProject, configurations: Option[String] = None) {
+
+  def apply(version: String) = {
+    val projectRef = crossProject.ref(version)
+    configurations.fold(projectRef: ClasspathDependency)(projectRef % _)
+  }
+
+}


### PR DESCRIPTION
Allows specifying configuration for cross project dependencies, e.g.

``` scala
Project("foo", file("foo")).cross.dependsOn(otherCrossProject % "test")
```

Similar to `sbt.ModuleID`.
